### PR TITLE
Typo in unsubscription implementation

### DIFF
--- a/dom-event-dispatch.md
+++ b/dom-event-dispatch.md
@@ -56,7 +56,7 @@ class EventTarget {
             // On unsubscription, remove the listener
             return _=> {
 
-                let index = this.@listeners.find(
+                let index = this.@listeners.findIndex(
                     listener => listener.observer === observer);
 
                 if (index >= 0)


### PR DESCRIPTION
`Array.prototype.find` returns the element itself, hence `Array.prototype.findIndex` should be used.