### PR TITLE
Add a subscription argument to next

### DIFF
--- a/es-observable-tests/es-observable-tests.js
+++ b/es-observable-tests/es-observable-tests.js
@@ -1,6 +1,6 @@
-/*=esdown=*/(function(fn, name) { if (typeof exports !== 'undefined') fn(exports, module); else if (typeof self !== 'undefined') fn(name === '*' ? self : (name ? self[name] = {} : {})); })(function(exports, module) { 'use strict'; var _esdown = {}; (function() { var exports = _esdown;
+(function(fn, name) { if (typeof exports !== 'undefined') fn(exports, module); else if (typeof self !== 'undefined') fn(name === '*' ? self : (name ? self[name] = {} : {})); })(function(exports, module) { 'use strict'; var _esdown = {}; (function() { var exports = _esdown;
 
-var VERSION = "1.1.2";
+var VERSION = "1.1.8";
 
 var GLOBAL = (function() {
 
@@ -325,7 +325,7 @@ exports.asyncIter = asyncIterator;
 })();
 
 var __M; (function(a) { var list = Array(a.length / 2); __M = function(i) { var m = list[i], f, e, ee; if (typeof m !== 'function') return m.exports; f = m; m = { exports: i ? {} : exports }; f(list[i] = m, e = m.exports); ee = m.exports; if (ee && ee !== e && !('default' in ee)) ee['default'] = ee; return ee; }; for (var i = 0; i < a.length; i += 2) { var j = Math.abs(a[i]); list[j] = a[i + 1]; if (a[i] >= 0) __M(j); } })([
-16, function(module, exports) {
+18, function(module, exports) {
 
 var OP_toString = Object.prototype.toString,
     OP_hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -495,7 +495,7 @@ exports.Test = Test;
 
 
 },
-17, function(module, exports) {
+16, function(module, exports) {
 
 var ELEMENT_ID = "moon-unit";
 
@@ -608,7 +608,7 @@ exports.HtmlLogger = HtmlLogger;
 
 
 },
-18, function(module, exports) {
+17, function(module, exports) {
 
 var Style = {
 
@@ -713,8 +713,8 @@ exports.NodeLogger = NodeLogger;
 },
 15, function(module, exports) {
 
-var HtmlLogger = __M(17).HtmlLogger;
-var NodeLogger = __M(18).NodeLogger;
+var HtmlLogger = __M(16).HtmlLogger;
+var NodeLogger = __M(17).NodeLogger;
 
 var Logger = (typeof global === "object" && global.process) ?
     NodeLogger :
@@ -726,7 +726,7 @@ exports.Logger = Logger;
 },
 14, function(module, exports) {
 
-var Test = __M(16).Test;
+var Test = __M(18).Test;
 var Logger = __M(15).Logger;
 
 var TestRunner = _esdown.class(function(__) { var TestRunner;
@@ -1676,12 +1676,36 @@ exports["default"] = {
 
         }).subscribe({
 
-            next: function(value) { for (var args = [], __$0 = 1; __$0 < arguments.length; ++__$0) args.push(arguments[__$0]); 
+            next: function(value) {
                 test._("Input value is forwarded to the observer")
                 .equals(value, token);
             }
-
         });
+    },
+
+    "Subscription argument": function(test, __$0) { var __$1; var Observable = (__$1 = _esdown.objd(__$0), __$1.Observable); 
+
+        var values = [], subscriptionArg;
+
+        var subscription = new Observable(function(observer) {
+
+            observer.next(1);
+            observer.next(2);
+
+        }).subscribe({
+
+            next: function(value, sub) {
+                subscriptionArg = sub;
+                values.push(value);
+                sub.unsubscribe();
+            }
+        });
+
+        test
+        ._("Subscription object is provided as second argument to next")
+        .assert(subscription === subscriptionArg)
+        ._("Next is not called after subscription is cancelled")
+        .equals(values, [1]);
     },
 
     "Return value": function(test, __$0) { var __$1; var Observable = (__$1 = _esdown.objd(__$0), __$1.Observable); 

--- a/es-observable-tests/package.json
+++ b/es-observable-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "es-observable-tests",
-    "version": "0.2.8",
+    "version": "0.3.0",
     "description": "Unit tests for es-observable",
     "repository": {
         "type": "git",

--- a/spec/prototype-properties.html
+++ b/spec/prototype-properties.html
@@ -82,13 +82,11 @@
     1. Let _next_ be a new built-in function object as defined in Observable.prototype.forEach Next Functions.
     1. Set the [[CallbackFn]] internal slot of _next_ to _callbackFn_.
     1. Set the [[Reject]] internal slot of _next_ to _promiseCapability_.[[Reject]].
-    1. Set the [[Subscription]] internal slot of _next_ to *undefined*.
     1. Perform CreateDataProperty(_observer_, `"next"`, _next_).
     1. Perform CreateDataProperty(_observer_, `"error"`, _promiseCapability_.[[Reject]]).
     1. Perform CreateDataProperty(_observer_, `"complete"`, _promiseCapability_.[[Resolve]]).
     1. Let _subscription_ be Invoke(_O_, `"subscribe"`, «‍ _observer_ »).
     1. IfAbruptRejectPromise(_subscription_, _promiseCapability_).
-    1. Set the [[Subscription]] internal slot of _next_ to _subscription_.
     1. Return _promiseCapability_.[[Promise]].
   </emu-alg>
 
@@ -97,9 +95,9 @@
   <emu-clause id="observable-prototype-foreach-next-functions">
     <h1>Observable.prototype.forEach Next Functions</h1>
 
-    <p>An Observable.prototype.forEach next function is an anonymous built-in function that is used to process each element of an observable sequence when _forEach_ is invoked. Each Observable.prototype.forEach next function has [[CallbackFn]], [[Reject]] and [[Subscription]] internal slots.</p>
+    <p>An Observable.prototype.forEach next function is an anonymous built-in function that is used to process each element of an observable sequence when _forEach_ is invoked. Each Observable.prototype.forEach next function has [[CallbackFn]] and [[Reject]] internal slots.</p>
 
-    <p>When an Observable.prototype.forEach next function _F_ is called with argument _x_, the following steps are taken:</p>
+    <p>When an Observable.prototype.forEach next function _F_ is called with arguments _x_ and _subscription_, the following steps are taken:</p>
 
     <emu-alg>
       1. Let _callbackFn_ be the value of the [[CallbackFn]] internal slot of _F_.
@@ -107,7 +105,6 @@
       1. If _result_ is an abrupt completion, then
         1. Let _promiseReject_ be the value of the [[Reject]] internal slot of _F_.
         1. Let _rejectResult_ be ! Call(_promiseReject_, `undefined`, « _result_.[[value]] »).
-        1. Let _subscription_ be _F_'s [[Subscription]] internal slot.
         1. Perform ? Invoke(_subscription_, `"unsubscribe"`, «‍ »).
         1. Return *undefined*.
       1. Return Completion(_result_).

--- a/spec/subscription-observer.html
+++ b/spec/subscription-observer.html
@@ -34,7 +34,7 @@
       1. If _result_ is not an abrupt completion, then
         1. Let _nextMethod_ be _result_.[[value]].
         1. If _nextMethod_ is *undefined*, let _result_ be NormalCompletion(*undefined*).
-        1. Else, let _result_ be Call(_nextMethod_, _observer_, « ‍_value_ »).
+        1. Else, let _result_ be Call(_nextMethod_, _observer_, « ‍_value_, _subscription_ »).
       1. If _result_ is an abrupt completion, then
         1. Perform ? CloseSubscription(_subscription_).
       1. Return Completion(_result_).

--- a/src/Observable.js
+++ b/src/Observable.js
@@ -186,7 +186,7 @@ SubscriptionObserver.prototype = nonEnum({
                 return undefined;
 
             // Send the next value to the sink
-            return m.call(observer, value);
+            return m.call(observer, value, subscription);
 
         } catch (e) {
 
@@ -282,11 +282,9 @@ export class Observable {
             if (typeof fn !== "function")
                 throw new TypeError(fn + " is not a function");
 
-            let subscription;
+            this.subscribe({
 
-            subscription = this.subscribe({
-
-                next(value) {
+                next(value, subscription) {
 
                     try {
 

--- a/test/observer-next.js
+++ b/test/observer-next.js
@@ -24,12 +24,36 @@ export default {
 
         }).subscribe({
 
-            next(value, ...args) {
+            next(value) {
                 test._("Input value is forwarded to the observer")
                 .equals(value, token);
             }
-
         });
+    },
+
+    "Subscription argument" (test, { Observable }) {
+
+        let values = [], subscriptionArg;
+
+        let subscription = new Observable(observer => {
+
+            observer.next(1);
+            observer.next(2);
+
+        }).subscribe({
+
+            next(value, sub) {
+                subscriptionArg = sub;
+                values.push(value);
+                sub.unsubscribe();
+            }
+        });
+
+        test
+        ._("Subscription object is provided as second argument to next")
+        .assert(subscription === subscriptionArg)
+        ._("Next is not called after subscription is cancelled")
+        .equals(values, [1]);
     },
 
     "Return value" (test, { Observable }) {


### PR DESCRIPTION
I think it's time to take a serious look at this, for a couple of reasons:

- Until recently, there was a long-standing bug with `forEach` dealing with synchronous emission.  The fix is simple but not obvious and relies upon the Promise constructor's auto-catching behavior.
- Some RxJS operators exhibit (probably) unintentional behavior when presented with synchronous emission.  For instance, the `first(pred)` combinator will continue to call `pred` multiple times if sent values synchronously.
- Users have reported similar issues. #83 
- Providing a `subscription` argument simplifies the handling of these cases.

The changes are almost trivial in the spec, and actually clean things up a bit.

@blesh  Thoughts?